### PR TITLE
Add JLCPCB PCBA conventions skill; fix broken pygerber invocation in gerbers skill

### DIFF
--- a/skills/gerbers/SKILL.md
+++ b/skills/gerbers/SKILL.md
@@ -2,12 +2,17 @@
 
 If no generated GERBERs exist, please request for the user to generate them or generate them yourself for the purpose of review only, in a separate directory.
 
-Generate GERBERs per layer with kicad-cli and then use pygerber in a venv to view them, rendered as images. uv pip install pygerber
+Generate GERBERs per layer with kicad-cli and then use pygerber in a venv to view them, rendered as images. Requires pygerber >= 2.0 - 1.x ships a different, specfile-driven CLI without this command. uv pip install pygerber
 
-For example: 
+    uv venv .venv-gerber --python 3.12
+    uv pip install --python .venv-gerber/Scripts/python.exe pygerber    # Linux/macOS: .venv-gerber/bin/python
+    pygerber raster-2d source.gbr -o output.png --dpi 600 -s copper_alpha
 
-'''To convert a Gerber file to PNG, use the pygerber gerber convert png command. For example, following command converts source.gbr (a copper layer) to a PNG at 600 DPMM resolution:
+`--dpi` is dots per *inch*, not per mm: a 65 mm board renders ~1535 px wide at 600 dpi. Use 600-1000 dpi so 0.1 mm outline lines stay visible, and expect harmless "Drawing zero surface circle" warnings on layers with tiny flashes. Render at least Edge_Cuts, F_Cu and B_Cu; keep the renders next to the documentation as evidence of the review.
 
-pygerber gerber convert png source.gbr -o output.png -d 600 -s copper_alpha'''
+Review checklist:
 
-Ensure that their are no unexpected shorts, that vias do not intersect, and that overall the board appears to be fabricatable. 
+- outline: the profile is closed, and every corner arc is the *minor* arc. A G02/G03 sweep of 270 deg curls into the board and encloses whatever sits near the corner - KiCad's DRC does not flag it, and it has shipped to a fab before.
+- copper: every connector and footprint field is present where the layout expects it, pours are contiguous, no unexpected shorts, vias do not intersect foreign copper.
+- keepouts: mounting holes and board-edge clearances are actually clear.
+- keep the renders with the project; re-run the review after any routing change.

--- a/skills/jlcpcb/SKILL.md
+++ b/skills/jlcpcb/SKILL.md
@@ -1,0 +1,47 @@
+# Skill for ordering PCBA from JLCPCB
+
+JLCPCB's placement preview is the only authority for their conventions:
+their help docs are gated and their 3D model library has per-package
+quirks. Upload BOM + CPL early in the quoting flow and confirm every
+convention below in the preview before paying. Fix one thing per preview
+round and re-check.
+
+## BOM / CPL conventions
+
+1. **Every BOM designator requires a CPL row - including through-hole
+   parts.** The BOM checker rejects lines with no CPL row and silently
+   drops them from assembly. Coordinates on THT rows are read by the
+   assembly team; the SMT machines ignore them.
+
+2. **CPL "Mid X / Mid Y" is the pad-field centre, not the footprint
+   origin.** KiCad parks a connector's origin on pin 1; JLC centres each
+   part model on its CPL point. Pin-1 origins render every through-hole
+   connector half a body off its pads, by a different amount per part.
+   SMT footprints' origins usually already coincide with their centres.
+
+3. **Rotation is read from the side the part is mounted on.** KiCad's
+   orientation is always CCW viewed from the top; a bottom-side part's
+   CPL angle must be complemented: `(360 - rot) % 360`.
+
+4. **One CPL row per physical part.** A footprint representing multiple
+   physical parts must be replaced by one component per physical part.
+   JLC's preview and operators place exactly one part per CPL row.
+
+5. **Model-zero corrections are per package family.** Some of JLC's 3D
+   models lie horizontal at rotation 0 while the footprint's pads run
+   vertical. Keep a per-part correction table; never assume a global
+   rotation convention.
+
+6. **Verify connector gender on the LCSC page category line** -
+   "Headers, Male Pins" vs "Headers, Receptacles, Female Sockets".
+   Prose descriptions and part-number series naming are not reliable
+   across vendors.
+
+## Enforcing the geometry conventions
+
+Conventions 2, 3 and 5 are easy to regress while editing an exporter.
+Have the exporter emit a side-by-side audit file from the CAD kernel -
+per reference: footprint origin, pad-field centre, rotation in both
+conventions - and test the shipped CPL against it: through-hole centres
+must differ from their origins, SMT centres must equal them, bottom-side
+rows must carry the complemented angle.


### PR DESCRIPTION
��Add JLCPCB PCBA conventions skill; fix broken pygerber invocation in gerbers skill

skills/jlcpcb: documents JLCPCB's placement and BOM conventions for
Standard PCBA with through-hole assembly:
- every BOM designator requires a CPL row, including through-hole parts;
  the BOM checker rejects lines with no CPL row and drops them from
  assembly
- CPL Mid X / Mid Y is the pad-field centre, not the footprint origin
  (KiCad parks a connector's origin on pin 1, while JLC centres each part
  model on its CPL point)
- rotation is read from the side the part is mounted on, so bottom-side
  parts carry (360 - rot) % 360 while KiCad measures CCW from the top
- one CPL row per physical part
- model-zero corrections are per package family
- connector gender must be confirmed on the LCSC page category line
- an audit-file pattern: the exporter emits a side-by-side record of
  footprint origin, pad-field centre, and rotation in both conventions,
  and a test replays the shipped CPL against it

skills/gerbers: the documented pygerber invocation
('pygerber gerber convert png ...') does not work on any released
pygerber. Verified against the release history:
- 1.0.0 / 1.1.0 (2021): flat CLI, no subcommands; 'pygerber --save <path>
  (--pillow|--blender) [--yaml|--json|--toml]'. No -o, no -d, no style
  names; -s is the save path.
- 2.0.0rc1 / rc2: no CLI entry point (no console script, no __main__).
- 2.0.0 .. 2.4.3: the subcommands are 'raster-2d' and 'render'.
Replace with the working 2.x invocation ('pygerber raster-2d ...
--dpi N -s copper_alpha'), note that --dpi is dots per inch, and add a
minimum-version constraint (1.x ships a different, specfile-driven CLI).

