### PR TITLE
Fold field lessons into schematic/export/PCB skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ npx skills add American-Embedded/kistack
 
 The package currently provides focused skills for schematic work, PCB review,
 parts and BOM decisions, KiCad exports, and Gerber review.
+
+## Field lessons (keep feeding back)
+
+When agents use these skills on real boards, fold hard-won failures back into the
+skill text and small helper scripts—do not leave them only in chat history.
+
+Recent additions from production use:
+
+- Schematic: netlist **and** pin-tip geometry; I2C/VDD level traps; PMIC EN
+  cold-start deadlocks; duplicate hierarchical BOM hazards
+- Export: Windows `kicad-cli` paths; avoid stale netlists; pcbnew DLL pitfalls;
+  `scripts/check_sch_geo_vs_netlist.py`
+- PCB: Specctra SES apply without moving footprints; freeroute keepout blindness
+
+Fork / install from your preferred remote (`American-Embedded/kistack` or a
+maintainer fork) and open PRs upstream when lessons generalize.

--- a/skills/export/SKILL.md
+++ b/skills/export/SKILL.md
@@ -118,3 +118,25 @@ Determine which PCB and scheamtic output commands you need to use (documentation
     --side bottom <project>.kicad_pcb
 
 Unless otherwise specified by the user, DRC and ERC errors will result in you throwing a FAILURE to export. If there is a FAILURE you can prompt them: "Should we proceed with export? Please reply with OVERRIDE to restart."
+
+### Windows / KiCad 10 agent notes (field-tested)
+
+- Prefer invoking the full path to `kicad-cli.exe`, e.g.  
+  `C:\Program Files\KiCad\10.0\bin\kicad-cli.exe`  
+  Do not assume `kicad-cli` is on PATH in PowerShell agent shells.
+- After schematic changes, always re-export netlist into the review folder **before** arguing about connectivity. Stale `netlist.kicad_net` has caused false confidence.
+- `import pcbnew` from a normal system Python often fails with `_pcbnew` DLL load errors on Windows. Prefer:
+  - `kicad-cli` for ERC/DRC/netlist/Gerbers/SVG/render, or
+  - KiCad's own Python (same `bin` directory on PATH) if you truly need pcbnew.
+- ERC Warnings such as `lib_symbol_mismatch` (embedded sheet symbol vs project lib) are not the same as electrical correctness. Still fix or acknowledge them; never treat "0 ERC errors" as "circuit is safe."
+- For LLM review packs, keep at least: `erc.rpt`, fresh `netlist` (sexpr or xml), schematic SVG/PDF zooms of power and buses, and PCB layer SVGs + DRC.
+
+### Optional geometry audit
+
+If labels/wires may be misaligned to pins, run:
+
+```bash
+python skills/export/scripts/check_sch_geo_vs_netlist.py path/to/sheet_or_project_dir
+```
+
+Use it together with a fresh `kicad-cli sch export netlist`, not instead of it.

--- a/skills/export/scripts/check_sch_geo_vs_netlist.py
+++ b/skills/export/scripts/check_sch_geo_vs_netlist.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Audit KiCad schematic pin-tip geometry vs nearby wires/labels.
+
+Field lesson: global labels placed near an IC without a wire to the pin
+endpoint leave pins electrically floating even when a stale netlist looks fine.
+
+Usage:
+  python check_sch_geo_vs_netlist.py path/to/Sheet.kicad_sch
+  python check_sch_geo_vs_netlist.py path/to/project_dir
+
+Coordinate rule (rotation 0 / 180 left-right pins):
+  world_x = ox + lx
+  world_y = oy - ly
+KiCad schematic Y is down. Re-export netlist with kicad-cli after edits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class PinDef:
+    num: str
+    name: str
+    lx: float
+    ly: float
+    angle: int
+
+
+@dataclass
+class PinHit:
+    ref: str
+    pin: str
+    name: str
+    x: float
+    y: float
+    connected: bool
+
+
+def _f(tok: str) -> float:
+    return float(tok)
+
+
+def _extract_balanced(text: str, start: int) -> str | None:
+    if start < 0 or start >= len(text) or text[start] != "(":
+        return None
+    depth = 0
+    for i in range(start, len(text)):
+        ch = text[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
+def parse_lib_pins_from_text(text: str) -> dict[str, list[PinDef]]:
+    """Map symbol name -> pins from unit drawings (…_1_1)."""
+    out: dict[str, list[PinDef]] = {}
+    for m in re.finditer(r'\(symbol "([^"]+)"', text):
+        name = m.group(1)
+        if name.endswith("_0_1") or name.endswith("_1_1"):
+            continue
+        block = _extract_balanced(text, m.start())
+        if not block:
+            continue
+        # Prefer the pins unit (…_1_1); fall back to all pins in block.
+        unit = None
+        for um in re.finditer(rf'\(symbol "{re.escape(name)}_1_1"', block):
+            unit = _extract_balanced(block, um.start())
+            break
+        src = unit or block
+        pins: list[PinDef] = []
+        for pm in re.finditer(
+            r'\(pin [^\n]*\n\s*\(at ([^\s]+) ([^\s]+) ([^\s]+)\)[\s\S]*?'
+            r'\(name "([^"]*)"[\s\S]*?\(number "([^"]*)"',
+            src,
+        ):
+            pins.append(
+                PinDef(
+                    num=pm.group(5),
+                    name=pm.group(4),
+                    lx=_f(pm.group(1)),
+                    ly=_f(pm.group(2)),
+                    angle=int(float(pm.group(3))),
+                )
+            )
+        if pins:
+            out[name] = pins
+            out[name.split(":")[-1]] = pins
+    return out
+
+
+def load_libs(sch_text: str, sch_path: Path) -> dict[str, list[PinDef]]:
+    libs = parse_lib_pins_from_text(sch_text)
+    for lib_path in list(sch_path.parent.glob("*.kicad_sym")) + list(
+        sch_path.parent.glob("libraries/*.kicad_sym")
+    ):
+        libs.update(
+            parse_lib_pins_from_text(
+                lib_path.read_text(encoding="utf-8", errors="replace")
+            )
+        )
+    return libs
+
+
+def abs_pin(ox: float, oy: float, lx: float, ly: float) -> tuple[float, float]:
+    return ox + lx, oy - ly
+
+
+def collect_attach_points(text: str) -> set[tuple[float, float]]:
+    pts: set[tuple[float, float]] = set()
+    for m in re.finditer(r"\(wire[\s\S]*?\(pts([\s\S]*?)\)\s*\(stroke", text):
+        for xy in re.finditer(r"\(xy ([^\s]+) ([^\s]+)\)", m.group(1)):
+            pts.add((_f(xy.group(1)), _f(xy.group(2))))
+    for m in re.finditer(
+        r'\((?:global_label|label|hierarchical_label) "([^"]+)"[\s\S]*?\(at ([^\s]+) ([^\s]+)',
+        text,
+    ):
+        pts.add((_f(m.group(2)), _f(m.group(3))))
+    for m in re.finditer(r"\(junction[\s\S]*?\(at ([^\s]+) ([^\s]+)\)", text):
+        pts.add((_f(m.group(1)), _f(m.group(2))))
+    for m in re.finditer(r"\(no_connect[\s\S]*?\(at ([^\s]+) ([^\s]+)\)", text):
+        pts.add((_f(m.group(1)), _f(m.group(2))))
+    return pts
+
+
+def near(
+    a: tuple[float, float], b: tuple[float, float], tol: float
+) -> bool:
+    return math.hypot(a[0] - b[0], a[1] - b[1]) <= tol
+
+
+def audit_sheet(path: Path, tol: float) -> list[PinHit]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    libs = load_libs(text, path)
+    attach = collect_attach_points(text)
+    body = re.sub(r"\(lib_symbols[\s\S]*?\n\t\)\n", "\n", text, count=1)
+    hits: list[PinHit] = []
+    for m in re.finditer(
+        r'\(symbol\s*\n\t\t\(lib_id "([^"]+)"\)\s*\n\t\t\(at ([^\s]+) ([^\s]+) ([^\s]+)\)'
+        r'[\s\S]*?\(property "Reference" "([^"]+)"',
+        body,
+    ):
+        lib_id = m.group(1)
+        ox, oy = _f(m.group(2)), _f(m.group(3))
+        ref = m.group(5)
+        if ref.startswith("#"):
+            continue
+        short = lib_id.split(":")[-1]
+        pins = libs.get(lib_id) or libs.get(short) or []
+        for p in pins:
+            x, y = abs_pin(ox, oy, p.lx, p.ly)
+            ok = any(near((x, y), q, tol) for q in attach)
+            hits.append(PinHit(ref, p.num, p.name, x, y, ok))
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path", type=Path, help="Sheet .kicad_sch or directory")
+    ap.add_argument("--tol", type=float, default=0.05)
+    args = ap.parse_args()
+
+    if args.path.is_dir():
+        paths = sorted(
+            p for p in args.path.glob("*.kicad_sch") if not p.name.startswith("~")
+        )
+    else:
+        paths = [args.path]
+
+    if not paths:
+        print("No .kicad_sch found", file=sys.stderr)
+        return 2
+
+    total_float = 0
+    for sch in paths:
+        hits = audit_sheet(sch, args.tol)
+        floating = [h for h in hits if not h.connected]
+        print(f"== {sch.name}: pins={len(hits)} floating~={len(floating)}")
+        for h in floating[:50]:
+            print(
+                f"  FLOAT {h.ref} pin {h.pin} ({h.name}) @ ({h.x:.2f},{h.y:.2f})"
+            )
+        if len(floating) > 50:
+            print(f"  ... {len(floating) - 50} more")
+        total_float += len(floating)
+
+    print(f"TOTAL_FLOATING~={total_float}")
+    print("Note: heuristic only. Re-export netlist with kicad-cli and reconcile.")
+    return 1 if total_float else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/pcb/SKILL.md
+++ b/skills/pcb/SKILL.md
@@ -10,3 +10,11 @@ Confirm with kicad-cli that DRC rules pass.
 Use kicad-cli to render SVGs of board layers to validate that their connections look reasonable.
 
 Use kicad-cli to render images of various areas of the PCB to validate interference with 3D models.
+
+### Autoroute / Specctra SES pitfalls (field-tested)
+
+- Prefer applying SES as **tracks and vias only**. KiCad `ImportSpecctraSES` can move footprints; avoid it when placement is already intentional.
+- Refuse or quarantine SES files that contain almost no wires (failed freeroute / empty session). A thin SES must not wipe a working board.
+- Freeroute often ignores courtyard/keepout intent (antenna keepouts, module courtyards). After autoroute, inspect those regions on SVG/render and hand-fix shorts/crossings.
+- Grid engines may leave clearance/unconnected violations even when ratsnest looks "mostly done." DRC + unconnected count is the exit criterion, not "autoroute finished."
+- After schematic net changes, sync pad nets / zones before trusting an old routed board. Schematic-parity DRC exists for a reason (`pcb drc --schematic-parity`).

--- a/skills/schematic/SKILL.md
+++ b/skills/schematic/SKILL.md
@@ -84,3 +84,43 @@ For the most part, your job with this skill will be adding adding decoupling, wi
 For example, for decoupling, think about derating depending on conditions, DC voltage, etc., and think about upstream circuitry like voltage regulators and switches and how much capacitance they can take.
 
 If you need to do more high-level work than the work described above as "most of your job," you can go ahead, but make sure you understand why it's necessary and do not add a lot of bloat. Always be able to explain your decisions logically without much possibility of dispute, and do explain them in your answer at the end, along with other liberties you took.
+
+### Connectivity truth: netlist AND pin geometry
+
+ERC and an old `netlist.kicad_net` are not enough.
+
+After schematic edits, **re-export** the netlist with `kicad-cli sch export netlist` and treat that export as the intent snapshot. Then also check that wires/global labels actually touch pin endpoints on the sheet.
+
+KiCad schematic coordinates are **Y-down**. Symbol-editor local pin `(lx, ly)` on a placed symbol at `(ox, oy)` with rotation 0 maps to:
+
+```text
+world_x = ox + lx
+world_y = oy - ly
+```
+
+Scripted wiring that uses the wrong transform (or places labels near an IC without hitting the pin tip) produces sheets that *look* labeled but geometrically leave pins floating. Labels sitting next to a body without a wire to the pin tip are a failure.
+
+If geometry and netlist disagree: **geometry on the current sheet wins for what would fabricate after a fresh export**; a stale netlist must not be trusted as "design intent" until you re-export. Prefer regenerating stub wires from known pin maps over hand-nudging hundreds of labels.
+
+A helper for this check lives at `skills/export/scripts/check_sch_geo_vs_netlist.py`.
+
+### Electrical review ERC will not catch
+
+Before you call a schematic "done," walk these with datasheets open. ERC will often stay green while the board is still dead or destructive.
+
+1. **I2C / open-drain levels vs device VDD**  
+   Pull-ups must not exceed each device's pin absolute max (often `VDD + 0.3 V`). Mixing 1.8 V sensors with 3.3 V pull-ups without level translation is a hard fail. If one device on the bus needs ≥2.5 V VDD (common for ALS parts), do not park it on a 1.8 V rail.
+
+2. **Multi-rail chicken-egg enables**  
+   If a PMIC's `EN*` pins enable the rail that powers the MCU/GreenPAK supposed to drive those same `EN*` pins, cold start can deadlock. Prefer a path that can assert EN before that rail exists (for example STATUS/ready → EN, or strap to an always-available logic high the datasheet allows). Never leave EN floating when the datasheet forbids it.
+
+3. **Duplicate subcircuits across hierarchical sheets**  
+   "Detail" sheets that re-place the same divider/battery symbols without DNP create parallel components and wrong thresholds. One sheet owns the real BOM parts; extras are DNP or text-only references.
+
+4. **Stub / incomplete symbols for complex ICs**  
+   A 4-pin "VDD/SDA/SCL/GND" stand-in for a part that also needs high-voltage AVDD (or many supplies) is not Phase-1 ready. Mark DNP and say so, or finish the supplies.
+
+5. **LDO current limits vs burst loads**  
+   Peak radio/MCU current may exceed LDO Imax; that is only acceptable if local bulk (e.g. polymer) is intentional and documented.
+
+Report these as electrical findings even when ERC is clean.


### PR DESCRIPTION
## Summary
- Schematic skill: netlist **and** pin-tip geometry, I2C/VDD level traps, PMIC EN cold-start deadlocks, hierarchical duplicate BOM hazards
- Export skill: Windows `kicad-cli` paths, stale netlist warning, pcbnew DLL pitfalls, geometry audit script
- PCB skill: Specctra SES apply without moving footprints; freeroute keepout blindness
- README: note to keep feeding field lessons back into the skills

## Test plan
- [ ] Read updated SKILL.md sections for clarity
- [ ] `python skills/export/scripts/check_sch_geo_vs_netlist.py <project_dir>` on a known sheet
- [ ] Confirm install via skills CLI still resolves schematic/export/pcb